### PR TITLE
Updated requirements for better modern compatibility

### DIFF
--- a/FlexibleDate/requirements.txt
+++ b/FlexibleDate/requirements.txt
@@ -1,4 +1,4 @@
-pydantic~=2.8.2
+pydantic~=2.13.0
 Unidecode~=1.3.8
 python-dateutil~=2.9.0.post0
 edtf~=5.0.0


### PR DESCRIPTION
This should give us better overall compatibility with modern Python versions and fix a lot of the annoying version stuff with TreeTapper, without meaningfully impacting our code